### PR TITLE
hotfix: use PORT as main app entrypoint

### DIFF
--- a/src/server/workers/bootstrap.ts
+++ b/src/server/workers/bootstrap.ts
@@ -4,13 +4,13 @@ import db from '../db';
 
 export const startWorker = async () => {
   try {
-    if (!env.worker_port)
+    if (!env.port)
       throw new Error('Worker http port not specified. Exiting...');
 
     await db.connect();
 
-    await bolt.start(env.worker_port);
-    console.log(`⚡️ Bolt app is running on port ${env.worker_port}!!!`);
+    await bolt.start(env.port);
+    console.log(`⚡️ Bolt app is running on port ${env.port}!!!`);
   } catch (e) {
     process.exit(1);
   }


### PR DESCRIPTION
Heroku needs the main entry point to be PORT and nothing else, UGH.